### PR TITLE
fix: remove enableWebsocket

### DIFF
--- a/src/config/queryClient.js
+++ b/src/config/queryClient.js
@@ -19,7 +19,6 @@ const {
   notifier: (data) => {
     console.log('notifier: ', data);
   },
-  enableWebsocket: true,
   keepPreviousData: true,
   // avoid refetching when same data are closely fetched
   staleTime: 1000, // ms


### PR DESCRIPTION
This PR removes the `enableWebsocket` option from the queryClient config because it does not exist.

closes #45 