### PR TITLE
ci: update cypress workflow and add release-please

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,56 +1,21 @@
-name: cypress tests
-on: [push]
+name: Cypress Tests
+
+# Control when the action will run
+on: push
+
+# This workflow is made up of one job that calls the reusable workflow in graasp-deploy
 jobs:
-  cypress-run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - name: set up node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-
-      - name: install yarn
-        # avoid checksum errors with github packages
-        run: YARN_CHECKSUM_BEHAVIOR=update yarn
-
-      - name: cypress run
-        uses: cypress-io/github-action@v4
-        env:
-          REACT_APP_API_HOST: http://localhost:3636
-          REACT_APP_GRAASP_DOMAIN: localhost
-          REACT_APP_GRAASP_APP_ID: id-1234567890
-          REACT_APP_MOCK_API: true
-          NODE_ENV: test
-        with:
-          install: false
-          config: baseUrl=http://localhost:3000
-          start: yarn start:ci
-          wait-on: 'http://localhost:3000'
-          wait-on-timeout: 180
-          browser: chrome
-          quiet: true
-          config-file: cypress.config.js
-
-      # after the test run completes
-      # store videos and any screenshots
-      # NOTE: screenshots will be generated only if E2E test failed
-      # thus we store screenshots only on failures
-      # Alternative: create and commit an empty cypress/screenshots folder
-      # to always have something to upload
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: cypress/screenshots
-      # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: cypress-videos
-          path: cypress/videos
-
-      - name: coverage report
-        run: npx nyc report --reporter=text-summary
+  cypress-tests:
+    name: Graasp app text input
+    uses: graasp/graasp-deploy/.github/workflows/cypress.yml@v1
+    # Insert required inputs based on repository
+    with:
+      # Test values
+      tsc: false
+      node-env-test: test
+      graasp-domain-test: localhost
+      graasp-app-id-test: id-1234567890
+      mock-api-test: true
+    # Insert required secrets based on repository with the following format: ${{ secrets.SECRET_NAME }}
+    secrets:
+      api-host-test: http://localhost:3636

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,6 +36,7 @@ jobs:
           TAG=$(echo '${{ steps.release.outputs.tag_name }}')
           JSON=$(jq -c --null-input --arg repository "$REPOSITORY" --arg tag "$TAG" '{"repository": $repository, "tag": $tag}')
           echo "json=$JSON" >> $GITHUB_OUTPUT
+
       # Trigger an 'on: repository_dispatch' workflow to run in graasp-deploy repository
       - name: Push tag to Graasp Deploy (Staging)
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,47 @@
+# Automate releases of new app versions
+name: Release new app version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: graasp-app-text-input
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"docs","section":"Documentation","hidden":false},{"type":"test","section":"Tests","hidden":false}]'
+
+      - uses: actions/checkout@v3
+
+      # creates minor and major tags that follow the latest release
+      - name: Tag major and minor versions
+        uses: jacobsvante/tag-major-minor-action@v0.1
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          major: ${{ steps.release.outputs.major }}
+          minor: ${{ steps.release.outputs.minor }}
+
+      # put created tag in an env variable to be sent to the dispatch
+      - name: Set tag
+        if: ${{ steps.release.outputs.release_created }}
+        id: set-tag
+        run: |
+          REPOSITORY=$(echo '${{ github.repository }}')
+          TAG=$(echo '${{ steps.release.outputs.tag_name }}')
+          JSON=$(jq -c --null-input --arg repository "$REPOSITORY" --arg tag "$TAG" '{"repository": $repository, "tag": $tag}')
+          echo "json=$JSON" >> $GITHUB_OUTPUT
+      # Trigger an 'on: repository_dispatch' workflow to run in graasp-deploy repository
+      - name: Push tag to Graasp Deploy (Staging)
+        if: ${{ steps.release.outputs.release_created }}
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: graasp/graasp-deploy
+          event-type: update-staging-version
+          client-payload: ${{ steps.set-tag.outputs.json }}


### PR DESCRIPTION
This PR updates the cypress workflow and adds release-please.

closes #58 as this uses the newer version of the re-usable workflow
closes #67
